### PR TITLE
ensure we can override ApiKey authorization, if specifically needed b…

### DIFF
--- a/src/Dojo.Net.Tests/CustomerClientTests.cs
+++ b/src/Dojo.Net.Tests/CustomerClientTests.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Dojo.Net.Tests
+{
+    public class CustomerClientTests
+    {
+        private const string SandboxKey = "sk_sandbox_c8oLGaI__msxsXbpBDpdtwJEz_eIhfQoKHmedqgZPCdBx59zpKZLSk8OPLT0cZolbeuYJSBvzDVVsYvtpo5RkQ";
+
+        private CustomersClient SystemUnderTest { get; set; }
+
+        public CustomerClientTests()
+        {
+            SystemUnderTest = new CustomersClient(
+                new HttpClient(),
+                new ApiKeyClientAuthorization(SandboxKey));
+        }
+
+        [Fact]
+        public async Task CreateAndDeleteCustomer_GivenValidRequest_ExpectCreated()
+        {
+            var createCustomerRequest = new CreateCustomerRequest
+            {
+                EmailAddress = "dojo.net.sdk@dojo.dev",
+                Name = "Dojo.NET"
+            };
+
+            var customer = await SystemUnderTest.CreateAsync(createCustomerRequest);
+
+            Assert.NotNull(customer);
+
+            await SystemUnderTest.DeleteAsync(customer.Id);
+
+            var existingCustomer = await SystemUnderTest.GetAsync(customer.Id);
+
+            Assert.Empty(existingCustomer);
+        }
+
+        [Fact]
+        public async Task GetPaymentMethods_GivenValidRequest_ExpectPaymentMethods()
+        {
+            var createCustomerRequest = new CreateCustomerRequest
+            {
+                EmailAddress = "dojo.net.sdk@dojo.dev",
+                Name = "Dojo.NET"
+            };
+            CustomerPaymentMethods customerPaymentMethods = null;
+
+
+            var customer = await SystemUnderTest.CreateAsync(createCustomerRequest);
+
+            try
+            {
+                var customerSecret = await SystemUnderTest.CreateCustomerSecretAsync(customer.Id);
+                customerPaymentMethods = await SystemUnderTest.GetPaymentMethodsAsync(customer.Id, "Basic " + customerSecret.Secret);
+            }
+            catch (Exception e)
+            {
+                await SystemUnderTest.DeleteAsync(customer.Id);
+            }
+
+            Assert.NotNull(customerPaymentMethods);
+        }
+    }
+}

--- a/src/Dojo.Net/ApiKeyClientAuthorization.cs
+++ b/src/Dojo.Net/ApiKeyClientAuthorization.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading.Tasks;
 using System.Net.Http;
 using System.Net.Http.Headers;
 
@@ -21,10 +20,9 @@ namespace Dojo.Net
             _apiKey = apiKey ?? throw new ArgumentNullException(nameof(apiKey));
         }
 
-        Task IClientAuthorization.AuthorizeRequestsAsync(HttpClient client)
+        void IClientAuthorization.AuthorizeRequests(HttpClient client)
         {
             client.DefaultRequestHeaders.Authorization =  new AuthenticationHeaderValue("Basic", _apiKey);
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Dojo.Net/ApiKeyClientAuthorization.cs
+++ b/src/Dojo.Net/ApiKeyClientAuthorization.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -23,9 +21,9 @@ namespace Dojo.Net
             _apiKey = apiKey ?? throw new ArgumentNullException(nameof(apiKey));
         }
 
-        Task IClientAuthorization.AuthorizeRequestAsync(HttpClient client, HttpRequestMessage httpRequestMessage)
+        Task IClientAuthorization.AuthorizeRequestsAsync(HttpClient client)
         {
-            httpRequestMessage.Headers.Authorization =  new AuthenticationHeaderValue("Basic", _apiKey);
+            client.DefaultRequestHeaders.Authorization =  new AuthenticationHeaderValue("Basic", _apiKey);
             return Task.CompletedTask;
         }
     }

--- a/src/Dojo.Net/BaseClient.cs
+++ b/src/Dojo.Net/BaseClient.cs
@@ -27,8 +27,8 @@ namespace Dojo.Net
         public BaseClient(HttpClient client, IClientAuthorization clientAuthorization)
         {
             Client = client ?? throw new ArgumentNullException(nameof(client));
-            var clientAuthorization1 = clientAuthorization ?? throw new ArgumentNullException(nameof(clientAuthorization));
-            clientAuthorization1.AuthorizeRequestsAsync(client);
+            _ = clientAuthorization ?? throw new ArgumentNullException(nameof(clientAuthorization));
+            clientAuthorization.AuthorizeRequestsAsync(client);
             Client.DefaultRequestHeaders.Add(VersionHeaderName, ApiVersion.Current);
         }
 

--- a/src/Dojo.Net/BaseClient.cs
+++ b/src/Dojo.Net/BaseClient.cs
@@ -1,8 +1,9 @@
-using System.Text;
 using System;
-using System.Threading.Tasks;
-using System.Threading;
 using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Dojo.Net
 {
@@ -12,12 +13,11 @@ namespace Dojo.Net
     public class BaseClient
     {
         private const string VersionHeaderName = "version";
-        private readonly IClientAuthorization _clientAuthorization;
 
         /// <summary>
         /// HttpClient instance
         /// </summary>
-        protected readonly HttpClient _client;
+        protected readonly HttpClient Client;
 
         /// <summary>
         /// Initializes a new instance of the <c>BaseClient</c> class.
@@ -26,8 +26,10 @@ namespace Dojo.Net
         /// <param name="clientAuthorization">The IClientAuthorization instance</param>
         public BaseClient(HttpClient client, IClientAuthorization clientAuthorization)
         {
-            _client = client ?? throw new ArgumentNullException(nameof(client));
-            _clientAuthorization = clientAuthorization ?? throw new ArgumentNullException(nameof(clientAuthorization));
+            Client = client ?? throw new ArgumentNullException(nameof(client));
+            var clientAuthorization1 = clientAuthorization ?? throw new ArgumentNullException(nameof(clientAuthorization));
+            clientAuthorization1.AuthorizeRequestsAsync(client);
+            Client.DefaultRequestHeaders.Add(VersionHeaderName, ApiVersion.Current);
         }
 
         /// <summary>
@@ -36,7 +38,7 @@ namespace Dojo.Net
         /// <param name="token">The cancellation token</param>
         protected Task<HttpClient> CreateHttpClientAsync(CancellationToken token)
         {
-            return Task.FromResult(_client);
+            return Task.FromResult(Client);
         }
 
         /// <summary>
@@ -45,10 +47,9 @@ namespace Dojo.Net
         /// <param name="client">The HttpClient instance</param>
         /// <param name="request">Http request message</param>
         /// <param name="urlBuilder">Url string builder</param>
-        protected async Task PrepareRequestAsync(HttpClient client, HttpRequestMessage request, StringBuilder urlBuilder)
+        protected Task PrepareRequestAsync(HttpClient client, HttpRequestMessage request, StringBuilder urlBuilder)
         {
-            request.Headers.Add(VersionHeaderName, ApiVersion.Current);
-            await _clientAuthorization.AuthorizeRequestAsync(client, request);
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/Dojo.Net/BaseClient.cs
+++ b/src/Dojo.Net/BaseClient.cs
@@ -28,7 +28,7 @@ namespace Dojo.Net
         {
             Client = client ?? throw new ArgumentNullException(nameof(client));
             _ = clientAuthorization ?? throw new ArgumentNullException(nameof(clientAuthorization));
-            clientAuthorization.AuthorizeRequestsAsync(client);
+            clientAuthorization.AuthorizeRequests(client);
             Client.DefaultRequestHeaders.Add(VersionHeaderName, ApiVersion.Current);
         }
 

--- a/src/Dojo.Net/IClientAuthorization.cs
+++ b/src/Dojo.Net/IClientAuthorization.cs
@@ -13,6 +13,6 @@ namespace Dojo.Net
         /// Authorize request
         /// </summary>
         /// <param name="client">The HttpClient instance</param>
-        Task AuthorizeRequestsAsync(HttpClient client);
+        void AuthorizeRequests(HttpClient client);
     }
 }

--- a/src/Dojo.Net/IClientAuthorization.cs
+++ b/src/Dojo.Net/IClientAuthorization.cs
@@ -13,7 +13,6 @@ namespace Dojo.Net
         /// Authorize request
         /// </summary>
         /// <param name="client">The HttpClient instance</param>
-        /// <param name="httpRequestMessage">The http request message</param>
-        Task AuthorizeRequestAsync(HttpClient client, HttpRequestMessage httpRequestMessage);
+        Task AuthorizeRequestsAsync(HttpClient client);
     }
 }


### PR DESCRIPTION
The current changes will support both ApiKey, as well as customer secret authorization.
Basically we want to be able to override the default ApiKey, if any given method requires a different auth policy.