### PR TITLE
[CON-3172] fix release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,4 +47,4 @@ jobs:
     #   run: dotnet nuget sign **\*.nupkg --certificate-path ${{ steps.write_file.outputs.filePath }} --certificate-password ${{ secrets.NUGET_SIGNING_CERT_PASSWORD }} --timestamper http://timestamp.digicert.com
 
     - name: Publish
-      run: dotnet nuget push **/*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}
+      run: dotnet nuget push **/*.nupkg -source 'https://api.nuget.org/v3/index.json' --api-key ${{secrets.NUGET_API_KEY}}


### PR DESCRIPTION
Parameters are different on `dotnet nuget` over the previous `nuget`